### PR TITLE
Hotfix protobuf blog post

### DIFF
--- a/_posts/2019-03-06-Serializing-your-data-with-Protobuf.markdown
+++ b/_posts/2019-03-06-Serializing-your-data-with-Protobuf.markdown
@@ -197,8 +197,10 @@ In addition, you must also declare the
 following dependencies:
 
 {% highlight text %}
-[requires]
+[build_requires]
 protoc_installer/3.6.1@bincrafters/stable
+
+[requires]
 protobuf/3.6.1@bincrafters/stable
 
 [generators]
@@ -226,7 +228,7 @@ to inform the compiler and the target platform:
 
 {% highlight bash %}
 conan install .. -s arch=armv7hf
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++``
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++
 cmake --build .
 {% endhighlight %}
 


### PR DESCRIPTION
Hi!

Kristian Jerpetjon on Slack asked:

> @uilianries any particular reason to not put the protoc_installer as a [build_requires] in the conanfile.txt ? reading your blogpost :slightly_smiling_face:

Indeed `protoc_installer` should be included as `[build_requires]`

Also, there is a small typo on the commands line.