### PR TITLE
#90 Add time to read

### DIFF
--- a/_includes/reading-time.html
+++ b/_includes/reading-time.html
@@ -1,0 +1,6 @@
+{% capture words %}
+{{ content | number_of_words | minus: 180 }}
+{% endcapture %}
+{% unless words contains '-' %}
+{{ words | plus: 150 | divided_by: 150 | append: ' minutes to read' }}
+{% endunless %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,7 +9,7 @@ comments: true
 	{% if page.subtitle %}
     <h1><small>{{ page.subtitle }}</small></h1>
     {% endif %}
-    <p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %}</p>
+	<p class="post-meta"><time datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>{% endif %} • <span itemprop="time-to-read" itemscope itemtype="http://schema.org/Text"><span itemprop="time-to-read">{% include reading-time.html %}</span></span></p>
   </header>
 
   <div class="post-content" itemprop="articleBody">
@@ -17,7 +17,7 @@ comments: true
   </div>
   {% if page.comments %}
 	<div id="disqus_thread"></div>
-         
+
 	<script>
 	    /**
 	     *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
@@ -31,9 +31,9 @@ comments: true
 	    */
 	    (function() {  // DON'T EDIT BELOW THIS LINE
 		var d = document, s = d.createElement('script');
-		
+
 		s.src = '//conancpp.disqus.com/embed.js';
-		
+
 		s.setAttribute('data-timestamp', +new Date());
 		(d.head || d.body).appendChild(s);
 	    })();


### PR DESCRIPTION
- Add time-to-read plugin for Jekyll: https://jekyllcodex.org/without-plugin/reading-time-indicator/

closes #90 

Preview:

![Screenshot_2019-09-27 Package ID modes control the ABI and the traceability of your dependencies(1)](https://user-images.githubusercontent.com/4870173/65771901-91e56600-e10f-11e9-9cfc-78cf7ad6216f.png)
