### PR TITLE
Small format fix

### DIFF
--- a/_posts/2019-09-27-package-id-modes.markdown
+++ b/_posts/2019-09-27-package-id-modes.markdown
@@ -150,7 +150,7 @@ class Library(ConanFile):
 
 Using the Conan client we can compute the package ID of the package that will
 be generated with the command
-[``conan info`](https://docs.conan.io/en/latest/reference/commands/consumer/info.html#conan-info):
+[conan info](https://docs.conan.io/en/latest/reference/commands/consumer/info.html#conan-info):
 
  ```bash
 ⇒  conan info . --profile=default


### PR DESCRIPTION
Remove incorrect character ` from the text.