### PR TITLE
add support for meta_title and meta_description attibutes in blog posts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,18 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <link rel="canonical" href="{{ page.canonical }}">
     <meta name="description" content="{{ page.description }}">
   {% else %}
-    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="title" content="{%- if page.meta_title -%}
+        {{ page.meta_title }}
+      {%- else -%}
+        {{ page.title }}
+      {% endif %}">
+    <meta name="description" content="{%- if page.meta_description -%}
+        {{ page.meta_description }}
+      {%- elsif page.excerpt -%}
+        {{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}
+      {%- else -%}
+        {{ site.description }}
+      {% endif %}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   {% endif %}
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
This enables better SEO optimization by enabling post authors to simply add the tags "meta_title" and "meta_description" to their post, and the values set will by used directly by search engine indexing.  If the fields are not defined, the previous behavior applies, where it uses the first 160 characters from the post description.