### PR TITLE
add support for -last_modified_at- field on blog posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -37,6 +37,11 @@ comments: true
             </span>
 
           </div>
+          <div class="post-meta pr-4 d-flex align-items-center">
+            {%- if page.last_modified_at -%}
+            Last updated:<span class="date">{{ page.last_modified_at | date: "%b %-d, %Y" }}</span>
+            {%- endif -%}
+          </div>
           <div class="post-share d-flex">
             <span class="d-inline-block mr-2">Share on: </span>
             {% include socials.html %}


### PR DESCRIPTION
As we will be going back and enhancing some blog posts, we're adding a "Last Modified" field under the original published date to reflect the new content.  Example:

        ---
        layout: post
        comments: false
        title: "..."
        last_modified_at: "2021-02-24"
        ---