### PR TITLE
read _config_local.yml so jekyll generates working image links locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 jekyll:
     image: jekyll/jekyll:pages
-    command: jekyll serve _config.yml --watch
+    command: jekyll serve _config.yml,_config_local.yml --watch
     ports:
         - 4000:4000
     volumes:

--- a/serve.sh
+++ b/serve.sh
@@ -1,1 +1,1 @@
-jekyll serve _config.yml --watch
+jekyll serve _config.yml,_config_local.yml --watch


### PR DESCRIPTION
on windows, the image links were not working.  by passing `_config_local.yml` at runtime, this causes the links to be generated from a working `url` field.  Of note, older posts referenced `page.url` for embedded images, while most newer posts reference `page.baseurl`.  I believe only links using `page.baseurl` work. 