### PR TITLE
add meta title and description to academy post

### DIFF
--- a/_posts/2020-09-24-New-conan-training-series.markdown
+++ b/_posts/2020-09-24-New-conan-training-series.markdown
@@ -2,6 +2,10 @@
 layout: post 
 comments: false 
 title: "Free Conan Training Series on JFrog Academy"
+last_modified_at: 2021-02-24
+meta_title: Free Conan Training Series on JFrog Academy - Blog - Conan.io
+meta_description: Happy to announce the launch of online training courses, free
+to anyone who is interested in learning Conan - the C/C++ Package Manager.
 ---
 
 Today we are very excited to announce a new milestone in the Conan project. We

--- a/_posts/2020-09-24-New-conan-training-series.markdown
+++ b/_posts/2020-09-24-New-conan-training-series.markdown
@@ -5,7 +5,7 @@ title: "Free Conan Training Series on JFrog Academy"
 last_modified_at: 2021-02-24
 meta_title: Free Conan Training Series on JFrog Academy - Blog - Conan.io
 meta_description: Happy to announce the launch of online training courses, free
-to anyone who is interested in learning Conan - the C/C++ Package Manager.
+to anyone who is interested in learning Conan - the free and open source C/C++ Package Manager.
 ---
 
 Today we are very excited to announce a new milestone in the Conan project. We


### PR DESCRIPTION
@BraverO provided these tags in the past but our blog did not support them. https://github.com/conan-io/conan-io.github.io/pull/164 and https://github.com/conan-io/conan-io.github.io/pull/165 add support for them. 
