### PR TITLE
Adding --future flag for posts with future dates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 jekyll:
     image: jekyll/jekyll:pages
-    command: jekyll serve _config.yml,_config_local.yml --watch
+    command: jekyll serve _config.yml,_config_local.yml --watch --future
     ports:
         - 4000:4000
     volumes:


### PR DESCRIPTION
Right now, if I'm writing a post for a date in the future, Jekyll won't render it. This flag makes jekyll render it.