### PR TITLE
Extend conan.bintray.com 2nd brownout to 24 hours

### DIFF
--- a/_posts/2021-10-28-conancenter-bintray-remote-eol.markdown
+++ b/_posts/2021-10-28-conancenter-bintray-remote-eol.markdown
@@ -28,9 +28,9 @@ about its EOL to anyone still using it. During those brownouts, the service will
 
   From 14:00 UTC / 15:00 CET to 20:00 UTC / 21:00 CET (6 hours).
 
-- #### 2nd brownout: November 23rd
+- #### 2nd brownout: November 23rd and 24th
 
-  From 14:00 UTC / 15:00 CET to 20:00 UTC / 21:00 CET (6 hours).
+  From November 23rd 14:00 UTC / 15:00 CET to November 24th 14:00 UTC / 15:00 CET (24 hours).
 
 - #### Shutdown: November 30th
 


### PR DESCRIPTION
Decided to extend 2nd brownout hours to increase the possible impact before de EOL