### PR TITLE
[hotfix] Protobuf: Remove link not ready

### DIFF
--- a/_posts/2019-03-06-Serializing-your-data-with-Protobuf.markdown
+++ b/_posts/2019-03-06-Serializing-your-data-with-Protobuf.markdown
@@ -14,7 +14,7 @@ format that can be stored and retrieved by the both sides.
 
 In this blog post, we will discuss the [Protobuf](https://developers.google.com/protocol-buffers)
 (Protocol Buffers), a project that can extend more than a simple library for serialization. The
-entire example presented here is available on [Github](https://github.com/conan-io/examples/tree/master/libraries/protobuf/serialization).
+entire example presented here is available on [Github](https://github.com/conan-io/examples2/tree/main/examples/libraries/protobuf/serialization).
 
 ## What is Protobuf?
 
@@ -217,7 +217,6 @@ cmake_layout
 
 Since Protobuf can be divided into two parts, `the protoc executable`, and the libraries, we will add the same package as `requires` and `tool_requires`, so
 it will be possible to install `protoc` for the same host architecture, as a build requirement, and libraries for a target architecture (aarch64) as a regular requirement.
-To obtain more information about using the same package as `requires` and `tool_requires`, please refer to the [using protobuf example](https://docs.conan.io/2/examples/graph/tool_requires/using_protobuf.html).
 As we are using CMake for this project, we need to declare
 the CMake generators [CMakeDeps](https://docs.conan.io/2/reference/tools/cmake/cmakedeps.html) and [CMakeToolchain](https://docs.conan.io/2/reference/tools/cmake/cmaketoolchain.html). The `CMakeDeps` generator will be responsible for generating the `FindProtobuf.cmake` file, and the `CMakeToolchain` generator will be responsible for generating the `conan_toolchain.cmake` file, which will be used by CMake to configure the project.
 Plus, we declared the layout [cmake_layout](https://docs.conan.io/2/reference/tools/cmake/cmake_layout.html) that will be responsible for organizing the files in the build directory.


### PR DESCRIPTION
- Update example repository to examples2
- Remove Protobuf example from documentation link (not ready).