### PR TITLE
[hotfix] Update CMake target for protobuf

### DIFF
--- a/_posts/2019-03-06-Serializing-your-data-with-Protobuf.markdown
+++ b/_posts/2019-03-06-Serializing-your-data-with-Protobuf.markdown
@@ -175,7 +175,7 @@ find_package(Protobuf REQUIRED CONFIG)
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS sensor.proto)
 
 add_executable(${PROJECT_NAME} main.cc ${PROTO_SRCS} ${PROTO_HDRS})
-target_link_libraries(${PROJECT_NAME} PUBLIC protobuf::protobuf)
+target_link_libraries(${PROJECT_NAME} PUBLIC protobuf::libprotobuf)
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_BINARY_DIR})
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
 {% endhighlight %}


### PR DESCRIPTION
According to the official documentation, the Protobuf target for its libraries should be `protobuf::libprotobuf`:

https://cmake.org/cmake/help/latest/module/FindProtobuf.html

kudos to SpaceIM